### PR TITLE
Fixed merging translations into existing i18n config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,12 +202,12 @@ export const zitadelPlugin: ZitadelPlugin = (config) => {
             translations: {
                 ...incomingConfig.i18n?.translations,
                 de: {
-                    ...incomingConfig.i18n?.translations?.de,
                     ...translations.de
+                    ...incomingConfig.i18n?.translations?.de,
                 },
                 en: {
-                    ...incomingConfig.i18n?.translations?.en,
                     ...translations.en
+                    ...incomingConfig.i18n?.translations?.en,
                 }
             }
         }


### PR DESCRIPTION
The merge was in the incorrect order so you could never use your own translation.